### PR TITLE
use markdown when rendering docs

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,0 +1,18 @@
+--- !ruby/object:RDoc::Options 
+encoding: 
+static_path: []
+
+rdoc_include: 
+- .
+charset: UTF-8
+exclude: 
+hyperlink_all: false
+line_numbers: false
+main_page: README.md
+markup: markdown
+page_dir: 
+show_hash: false
+tab_width: 8
+title: Always Be Contributing Documentation
+visibility: :protected
+webcvs: 

--- a/always_be_contributing.gemspec
+++ b/always_be_contributing.gemspec
@@ -13,10 +13,9 @@ Gem::Specification.new do |spec|
     Always Be Contributing counts who has
     contributing most to your organization on Github.
   EOF
-  spec.extra_rdoc_files  = %w[ LICENSE README.rdoc ]
-  spec.rdoc_options      << "--charset=UTF-8" <<
-                            "--title" << "Always Be Contributing Documentation" <<
-                            "--main"  << "README.rdoc"
+  spec.extra_rdoc_files  = %w[ LICENSE README.md ]
+  spec.rdoc_options      << "--title" << "Always Be Contributing Documentation" <<
+                            "--main"  << "README.md"
   spec.license           = 'ISC'
   spec.summary           = spec.description.split(/\.\s+/).first
   spec.files             = `git ls-files`.split($/)
@@ -25,5 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rdoc'
+  spec.add_development_dependency 'rdoc', '>= 4.0.0'
 end


### PR DESCRIPTION
This fixes the default docs from a gem install and `rake rdoc`. It was trying to use `README.rdoc` as the main doc after the file no longer existed.
