### PR TITLE
Added 2-factor auth instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ You've got a team of Committers. But who's the best?
 [rdoc](http://rdoc.info/gems/always_be_contributing)
 [bugs](https://github.com/josephholsten/always_be_contributing/issues)
 
+## Two-Factor Authentication
+If you're using Two-Factor Authentication the password you use when configuring your github credentials should be your 40 character access token. 
+Create an Personal access token [here](https://github.com/settings/applications)
+
 ## TODO
 
 * Travis CI integrations


### PR DESCRIPTION
I recently added 2-factor auth to my github account and then ran into auth issues with always_be_contributing. I'm sure someone else will run into this issue.
